### PR TITLE
Added files via upload

### DIFF
--- a/CLOUDSTACK-9285.patch
+++ b/CLOUDSTACK-9285.patch
@@ -1,0 +1,26 @@
+From c17250da5aca931438b5b031839e1dad20955f16 Mon Sep 17 00:00:00 2001
+From: Simon Weller <sweller@ena.com>
+Date: Fri, 4 Mar 2016 07:40:27 -0600
+Subject: [PATCH] CLOUDSTACK-9285 - Agent thows an exception that can never be
+ recovered from
+
+---
+ agent/src/com/cloud/agent/Agent.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/agent/src/com/cloud/agent/Agent.java b/agent/src/com/cloud/agent/Agent.java
+index 994e822..7ed3fda 100644
+--- a/agent/src/com/cloud/agent/Agent.java
++++ b/agent/src/com/cloud/agent/Agent.java
+@@ -412,7 +412,8 @@ public class Agent implements HandlerFactory, IAgentControl {
+             try {
+                 _connection.start();
+             } catch (final NioConnectionException e) {
+-                throw new CloudRuntimeException("Unable to start the connection!", e);
++		s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
+             }
+             _shell.getBackoffAlgorithm().waitBeforeRetry();
+         } while (!_connection.isStartup());
+-- 
+1.8.5.6
+


### PR DESCRIPTION
CLOUDSTACK-9285 - Agent thows an exception that can never be recovered from.
This change forces the agent to attempt a reconnect after the exception is thrown.
