### PR TITLE
Allow hidden configuration parameters to be shown under certain condi…

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/org/apache/cloudstack/api/ApiConstants.java
@@ -636,6 +636,8 @@ public class ApiConstants {
 
     public static final String ADMIN = "admin";
 
+    public static final String SHOWHIDDEN = "showhidden";
+
     public enum HostDetails {
         all, capacity, events, stats, min;
     }

--- a/api/src/org/apache/cloudstack/api/command/admin/config/ListCfgsByCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/config/ListCfgsByCmd.java
@@ -76,6 +76,12 @@ public class ListCfgsByCmd extends BaseListCmd {
                description = "the ID of the Account to update the parameter value for corresponding account")
     private Long accountId;
 
+    @Parameter(name = ApiConstants.SHOWHIDDEN,
+               type = CommandType.BOOLEAN,
+               description = "Whether to show hidden parameters")
+    private Boolean showHidden;
+
+
     // ///////////////////////////////////////////////////
     // ///////////////// Accessors ///////////////////////
     // ///////////////////////////////////////////////////
@@ -102,6 +108,13 @@ public class ListCfgsByCmd extends BaseListCmd {
 
     public Long getAccountId() {
         return accountId;
+    }
+
+    public Boolean getShowHidden() {
+        if(showHidden == null) {
+            showHidden = Boolean.FALSE;
+        }
+        return showHidden;
     }
 
     @Override

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -1954,6 +1954,15 @@ public enum Config {
             "the interval cloudstack sync with UCS manager for available blades in case user remove blades from chassis without notifying CloudStack",
             null),
 
+    AllowShowHiddenConfigViaApi(
+            "Advanced",
+            ManagementServer.class,
+            Boolean.class,
+            "com.cloud.configuration.allowshowhidden",
+            "false",
+            "Whether or not to allow showing hidden values via api",
+            null),
+
     RedundantRouterVrrpInterval(
             "Advanced",
             NetworkOrchestrationService.class,

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1652,6 +1652,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Long clusterId = cmd.getClusterId();
         final Long storagepoolId = cmd.getStoragepoolId();
         final Long accountId = cmd.getAccountId();
+        final Boolean showHidden = cmd.getShowHidden();
+
         String scope = null;
         Long id = null;
         int paramCountCheck = 0;
@@ -1701,8 +1703,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             sc.addAnd("category", SearchCriteria.Op.EQ, category);
         }
 
-        // hidden configurations are not displayed using the search API
-        sc.addAnd("category", SearchCriteria.Op.NEQ, "Hidden");
+        if (!showHidden) {
+            // hidden configurations are not displayed using the search API unless showHidden == true
+            sc.addAnd("category", SearchCriteria.Op.NEQ, "Hidden");
+        } else if (!Boolean.valueOf(_configs.get(Config.AllowShowHiddenConfigViaApi.key()))) {
+            throw new InvalidParameterValueException("showhidden not allowed");
+        }
 
         if (scope != null && !scope.isEmpty()) {
             // getting the list of parameters at requested scope


### PR DESCRIPTION
…tions

If the listConfigurations endpoint is called with the showhidden=true
parameter, and the com.cloud.configuration.allowshowhidden=true, then
hidden parameters can be queried and displayed.
