### PR TITLE
EB-1588 expose enlightenment toggle

### DIFF
--- a/client/WEB-INF/classes/resources/messages.properties
+++ b/client/WEB-INF/classes/resources/messages.properties
@@ -88,6 +88,7 @@ error.something.went.wrong.please.correct.the.following=Something went wrong; pl
 error.unable.to.reach.management.server=Unable to reach Management Server
 error.unresolved.internet.name=Your internet name cannot be resolved.
 label.extractable=Extractable
+label.enlightenment=Enlightenment
 force.delete.domain.warning=Warning\: Choosing this option will cause the deletion of all child domains and all associated accounts and their resources.
 force.delete=Force Delete
 force.remove.host.warning=Warning\: Choosing this option will cause CloudStack to forcefully stop all running virtual machines before removing this host from the cluster.

--- a/ui/dictionary.jsp
+++ b/ui/dictionary.jsp
@@ -117,6 +117,7 @@ dictionary = {
 'error.unable.to.reach.management.server': '<fmt:message key="error.unable.to.reach.management.server" />',
 'error.unresolved.internet.name': '<fmt:message key="error.unresolved.internet.name" />',
 'label.extractable': '<fmt:message key="label.extractable" />',
+'label.enlightenment': '<fmt:message key="label.enlightenment"/>',
 'force.delete.domain.warning': '<fmt:message key="force.delete.domain.warning" />',
 'force.delete': '<fmt:message key="force.delete" />',
 'force.remove': '<fmt:message key="force.remove" />',

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -497,6 +497,28 @@
                                         }
                                     },
 
+                                    enlightenment: {
+                                        label: "label.enlightenment",
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "none",
+                                                description: "none"
+                                            });
+                                            items.push({
+                                                id: "true",
+                                                description: "true"
+                                            });
+                                            items.push({
+                                                id: "false",
+                                                description: "false"
+                                            });
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
+                                    },
+
                                     isExtractable: {
                                         label: "label.extractable",
                                         docID: 'helpRegisterTemplateExtractable',
@@ -579,6 +601,12 @@
                                 if (args.$form.find('.form-item[rel=isrouting]').is(':visible')) {
                                     $.extend(data, {
                                         isrouting: (args.data.isrouting === 'on')
+                                    });
+                                }
+
+                                if(args.data.enlightenment != "none") {
+                                    $.extend(data, {
+                                        'details[0].enlightenment': args.data.enlightenment
                                     });
                                 }
 


### PR DESCRIPTION
## Description
Adding the option to set enlightenment in create template dialog. It should be a drop down box, where the valid values are "none", where no vm detail is passed, "true" where enlightenment=true is passed, or "false", where enlightenment=false is passed.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
